### PR TITLE
Intersect polygons with circles and arcs, check for intersections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ## Upcoming - 0.3.0
 ### ⭐ Added
  - Checking intersections between great circle arcs (https://github.com/stellarguesser/spherical-geometry/pull/6)
+ - Checking intersections between polygons and great circles or great circle arcs (https://github.com/stellarguesser/spherical-geometry/pull/8)
+ - Checking if great circles/great circles arcs intersect one another (`true`/`false`, not returning the list of intersections) (https://github.com/stellarguesser/spherical-geometry/pull/8)
 
 ### 🐛 Fixed
  - Fixed the example in README (GeCAA Theory task 7) (https://github.com/stellarguesser/spherical-geometry/pull/5)

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ State key:
 | Intersection with great circle                                                                           |  🟢   |
 | Clamped intersection with great circle (returning the closest endpoint if no intersection is on the arc) |  🟢   |
 | Intersection with another arc                                                                            |  🟢   |
-| **Polygons**                                                                                             |  🟡   |
+| **Polygons**                                                                                             |  🟢   |
 | Construction from vertices                                                                               |  🟢   |
 | Check if it contains a point                                                                             |  🟢   |
-| Check if it intersects a great circle                                                                    |  🔴   |
-| Check if it intersects a great circle arc                                                                |  🔴   |
+| Check if it intersects a great circle                                                                    |  🟢   |
+| Check if it intersects a great circle arc                                                                |  🟢   |

--- a/src/great_circle_arc.rs
+++ b/src/great_circle_arc.rs
@@ -115,7 +115,7 @@ impl GreatCircleArc {
         Ok(intersections)
     }
 
-    /// Returns the intersections of this great circle arc with a great circle
+    /// Checks if there exists an intersection between this great circle arc and the provided great circle
     ///
     /// # Errors
     /// Only propagates errors originating from [Self::intersect_great_circle], but handles [SphericalError::IdenticalGreatCircles] internally

--- a/src/great_circle_arc.rs
+++ b/src/great_circle_arc.rs
@@ -119,6 +119,8 @@ impl GreatCircleArc {
     ///
     /// # Errors
     /// If the great circles containing the arcs are (essentially) parallel (equal to each other) and overlapping, returns `SphericalError::IdenticalGreatCircles` as then there is an infinite amount of intersections.
+    ///
+    /// Propagates the rest of errors originating from [Self::intersect_great_circle]
     pub fn intersect_great_circle_arc(&self, other: &Self) -> Result<Vec<SphericalPoint>, SphericalError> {
         let circle = GreatCircle::from_arc(other);
         match self.intersect_great_circle(&circle) {
@@ -132,6 +134,31 @@ impl GreatCircleArc {
                         } else {
                             // They are parallel, but do not overlap each other
                             Ok(Vec::new())
+                        }
+                    }
+                    _ => Err(err),
+                }
+            }
+        }
+    }
+
+    /// Checks if there exists an intersection of this arc with the provided one
+    ///
+    /// # Errors
+    /// Propagates errors originating from [Self::intersect_great_circle] apart from [SphericalError::IdenticalGreatCircles] for which the meaning in this context can be determined
+    pub fn intersects_great_circle_arc(&self, other: &Self) -> Result<bool, SphericalError> {
+        let circle = GreatCircle::from_arc(other);
+        match self.intersect_great_circle(&circle) {
+            Ok(intersections) => Ok(intersections.into_iter().any(|intersection| other.contains_point(&intersection))),
+            Err(err) => {
+                match err {
+                    SphericalError::IdenticalGreatCircles => {
+                        if self.contains_point(&other.start) || self.contains_point(&other.end) || other.contains_point(&self.start) || other.contains_point(&self.end) {
+                            // They are parallel and overlap each other
+                            Ok(true)
+                        } else {
+                            // They are parallel, but do not overlap each other
+                            Ok(false)
                         }
                     }
                     _ => Err(err),

--- a/src/great_circle_arc.rs
+++ b/src/great_circle_arc.rs
@@ -120,7 +120,7 @@ impl GreatCircleArc {
     /// # Errors
     /// Only propagates errors originating from [Self::intersect_great_circle], but handles [SphericalError::IdenticalGreatCircles] internally
     pub fn intersects_great_circle(&self, circle: &GreatCircle) -> Result<bool, SphericalError> {
-        match self.intersect_great_circle(&circle) {
+        match self.intersect_great_circle(circle) {
             Ok(intersections) => Ok(!intersections.is_empty()),
             Err(err) => {
                 match err {

--- a/src/great_circle_arc.rs
+++ b/src/great_circle_arc.rs
@@ -115,6 +115,25 @@ impl GreatCircleArc {
         Ok(intersections)
     }
 
+    /// Returns the intersections of this great circle arc with a great circle
+    ///
+    /// # Errors
+    /// Only propagates errors originating from [Self::intersect_great_circle], but handles [SphericalError::IdenticalGreatCircles] internally
+    pub fn intersects_great_circle(&self, circle: &GreatCircle) -> Result<bool, SphericalError> {
+        match self.intersect_great_circle(&circle) {
+            Ok(intersections) => Ok(!intersections.is_empty()),
+            Err(err) => {
+                match err {
+                    SphericalError::IdenticalGreatCircles => {
+                        // They are parallel -> the arc is a part of the circle
+                        Ok(true)
+                    }
+                    _ => Err(err),
+                }
+            }
+        }
+    }
+
     /// Returns the intersections of this great circle arc with another one
     ///
     /// # Errors

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub use great_circle_arc::GreatCircleArc;
 pub use point::SphericalPoint;
 pub use polygon::{EdgeDirection, Polygon};
 
+pub(crate) const IDENTICAL_POINTS: f32 = 10e-5;
 pub(crate) const VEC_LEN_IS_ZERO: f32 = 10e-6;
 
 #[derive(Debug)]

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -158,11 +158,55 @@ impl Polygon {
     /// # Errors
     /// This function does not generate its own errors, but may propagate the following:
     ///  - If any of the edges fails to be constructed as a [GreatCircleArc], returns the corresponding error (see [GreatCircleArc::new]). This should however never happen, as that is checked when the polygon is constructed.
-    ///  - If an edge fails to be intersected with the arc, it returns the corresponding error (refer to [GreatCircleArc::intersect_great_circle_arc] for more details).
+    ///  - If an edge fails to be intersected with the arc, it returns the corresponding error (refer to [GreatCircleArc::intersects_great_circle_arc] for more details). Handles parallel circles as infinite intersections (returns `Ok(true)`) though.
     pub fn intersects_great_circle_arc(&self, arc: &GreatCircleArc) -> Result<bool, SphericalError> {
         for i in 0..self.vertices.len() - 1 {
             let edge = GreatCircleArc::new(self.vertices[i], self.vertices[i + 1])?;
             if edge.intersects_great_circle_arc(arc)? {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Returns the intersections of the edges of the polygon with a given great circle
+    ///
+    /// # Errors
+    /// This function does not generate its own errors, but may propagate the following:
+    ///  - If any of the edges fails to be constructed as a [GreatCircleArc], returns the corresponding error (see [GreatCircleArc::new]). This should however never happen, as that is checked when the polygon is constructed.
+    ///  - If an edge fails to be intersected with the circle, it returns the corresponding error (refer to [GreatCircle::intersect_great_circle_arc] for more details).
+    pub fn great_circle_intersections(&self, circle: &GreatCircle) -> Result<Vec<SphericalPoint>, SphericalError> {
+        let mut intersections = Vec::new();
+
+        for i in 0..self.vertices.len() - 1 {
+            let edge = GreatCircleArc::new(self.vertices[i], self.vertices[i + 1])?;
+            let ints = edge.intersect_great_circle(circle)?;
+            for int in ints {
+                if intersections
+                    .iter()
+                    .any(|intersection: &SphericalPoint| intersection.approximately_equals(&int, crate::IDENTICAL_POINTS))
+                {
+                    continue;
+                }
+                intersections.push(int);
+            }
+        }
+
+        Ok(intersections)
+    }
+
+    /// Checks if there exists an intersection of the edges of the polygon with the provided [GreatCircle]
+    ///
+    /// This function will in theory return errors less often than [Self::great_circle_intersections] as it handles the cases when circles are parallel
+    ///
+    /// # Errors
+    /// This function does not generate its own errors, but may propagate the following:
+    ///  - If any of the edges fails to be constructed as a [GreatCircleArc], returns the corresponding error (see [GreatCircleArc::new]). This should however never happen, as that is checked when the polygon is constructed.
+    ///  - If an edge fails to be intersected with the circle, it returns the corresponding error (refer to [GreatCircle::intersects_great_circle_arc] for more details). Handles parallel circles as infinite intersections (returns `Ok(true)`) though.
+    pub fn intersects_great_circle(&self, circle: &GreatCircle) -> Result<bool, SphericalError> {
+        for i in 0..self.vertices.len() - 1 {
+            let edge = GreatCircleArc::new(self.vertices[i], self.vertices[i + 1])?;
+            if edge.intersects_great_circle(circle)? {
                 return Ok(true);
             }
         }
@@ -333,5 +377,179 @@ mod tests {
         let expected_i_2 = SphericalPoint::new(0.63939, 0.58435);
         assert!(intersections_2_7.iter().any(|p| expected_i_1.approximately_equals(p, tolerance)));
         assert!(intersections_2_7.iter().any(|p| expected_i_2.approximately_equals(p, tolerance)));
+    }
+
+    #[test]
+    fn intersects_circle() {
+        let polygon_1 = Polygon::new(
+            vec![
+                SphericalPoint::new(0.0, PI / 3.0),
+                SphericalPoint::new(-2.0 * PI / 3.0, PI / 3.0),
+                SphericalPoint::new(2.0 * PI / 3.0, PI / 3.0),
+            ],
+            EdgeDirection::CounterClockwise,
+        )
+        .expect("The polygon should be constructable");
+
+        let circle_1 = GreatCircle::new(SphericalPoint::new(0.0, PI / 3.0), SphericalPoint::new(-2.0 * PI / 3.0, PI / 3.0)).expect("The circle should be constructable");
+        assert!(polygon_1
+            .intersects_great_circle(&circle_1)
+            .expect("It should be possible to determine if the circle intersects the polygon"));
+
+        let circle_2 = GreatCircle::new(SphericalPoint::new(0.0, 0.0), SphericalPoint::new(0.0, PI / 3.0)).expect("The circle should be constructable");
+        assert!(polygon_1
+            .intersects_great_circle(&circle_2)
+            .expect("It should be possible to determine if the circle intersects the polygon"));
+
+        let circle_3 = GreatCircle::new(SphericalPoint::new(0.0, 0.0), SphericalPoint::new(0.0, PI / 2.0)).expect("The circle should be constructable");
+        assert!(polygon_1
+            .intersects_great_circle(&circle_3)
+            .expect("It should be possible to determine if the circle intersects the polygon"));
+
+        let circle_4 = GreatCircle::new(SphericalPoint::new(0.0, PI / 4.0), SphericalPoint::new(PI / 6.0, PI / 5.0)).expect("The circle should be constructable");
+        assert!(!polygon_1
+            .intersects_great_circle(&circle_4)
+            .expect("It should be possible to determine if the circle intersects the polygon"));
+
+        let polygon_2 = Polygon::new(
+            vec![
+                SphericalPoint::new(0.0, 0.0),
+                SphericalPoint::new(0.0, 0.5),
+                SphericalPoint::new(1.2, 0.5),
+                SphericalPoint::new(0.8, 0.25),
+                SphericalPoint::new(1.2, 0.0),
+            ],
+            EdgeDirection::CounterClockwise,
+        )
+        .expect("The polygon should be constructable");
+
+        let circle_5 = GreatCircle::new(SphericalPoint::new(1.0, 0.5), SphericalPoint::new(0.9, -0.15)).expect("The circle should be constructable");
+        assert!(polygon_2
+            .intersects_great_circle(&circle_5)
+            .expect("It should be possible to determine if the circle intersects the polygon"));
+
+        let circle_6 = GreatCircle::new(SphericalPoint::new(1.0, -0.5), SphericalPoint::new(0.9, -0.15)).expect("The circle should be constructable");
+        assert!(polygon_2
+            .intersects_great_circle(&circle_6)
+            .expect("It should be possible to determine if the circle intersects the polygon"));
+
+        let circle_7 = GreatCircle::new(SphericalPoint::new(-0.1, -0.3), SphericalPoint::new(0.8, 0.7)).expect("The circle should be constructable");
+        assert!(polygon_2
+            .intersects_great_circle(&circle_7)
+            .expect("It should be possible to determine if the circle intersects the polygon"));
+
+        let circle_8 = GreatCircle::new(SphericalPoint::new(0.0, -0.5), SphericalPoint::new(0.9, -0.2)).expect("The circle should be constructable");
+        assert!(!polygon_2
+            .intersects_great_circle(&circle_8)
+            .expect("It should be possible to determine if the circle intersects the polygon"));
+    }
+
+    #[test]
+    fn circle_intersections() {
+        let tolerance = 10e-4;
+
+        let polygon_1 = Polygon::new(
+            vec![
+                SphericalPoint::new(0.0, PI / 3.0),
+                SphericalPoint::new(-2.0 * PI / 3.0, PI / 3.0),
+                SphericalPoint::new(2.0 * PI / 3.0, PI / 3.0),
+            ],
+            EdgeDirection::CounterClockwise,
+        )
+        .expect("The polygon should be constructable");
+
+        let circle_1 = GreatCircle::new(SphericalPoint::new(0.0, PI / 3.0), SphericalPoint::new(-2.0 * PI / 3.0, PI / 3.0)).expect("The circle should be constructable");
+        assert!(matches!(polygon_1.great_circle_intersections(&circle_1), Err(SphericalError::IdenticalGreatCircles)));
+
+        let circle_2 = GreatCircle::new(SphericalPoint::new(0.0, 0.0), SphericalPoint::new(0.0, PI / 3.0)).expect("The circle should be constructable");
+        let expected_i_1 = SphericalPoint::new(0.0, PI / 3.0);
+        let expected_i_2 = SphericalPoint::new(PI, 1.28976);
+        let intersections_1_2 = polygon_1
+            .great_circle_intersections(&circle_2)
+            .expect("It should be possible to determine if the circle intersects the polygon");
+        assert_eq!(intersections_1_2.len(), 2);
+        assert!(intersections_1_2.iter().any(|p| expected_i_1.approximately_equals(p, tolerance)));
+        assert!(intersections_1_2.iter().any(|p| expected_i_2.approximately_equals(p, tolerance)));
+
+        let circle_3 = GreatCircle::new(SphericalPoint::new(0.0, 0.0), SphericalPoint::new(0.0, PI / 2.0)).expect("The circle should be constructable");
+        let expected_i_1 = SphericalPoint::new(0.0, PI / 3.0);
+        let expected_i_2 = SphericalPoint::new(PI, 1.28976);
+        let intersections_1_3 = polygon_1
+            .great_circle_intersections(&circle_3)
+            .expect("It should be possible to determine if the circle intersects the polygon");
+        assert_eq!(intersections_1_3.len(), 2);
+        assert!(intersections_1_3.iter().any(|p| expected_i_1.approximately_equals(p, tolerance)));
+        assert!(intersections_1_3.iter().any(|p| expected_i_2.approximately_equals(p, tolerance)));
+
+        let circle_4 = GreatCircle::new(SphericalPoint::new(0.0, PI / 4.0), SphericalPoint::new(PI / 6.0, PI / 5.0)).expect("The circle should be constructable");
+        let intersections_1_4 = polygon_1
+            .great_circle_intersections(&circle_4)
+            .expect("It should be possible to determine if the circle intersects the polygon");
+        assert!(intersections_1_4.is_empty());
+
+        let polygon_2 = Polygon::new(
+            vec![
+                SphericalPoint::new(0.0, 0.0),
+                SphericalPoint::new(0.0, 0.5),
+                SphericalPoint::new(1.2, 0.5),
+                SphericalPoint::new(0.8, 0.25),
+                SphericalPoint::new(1.2, 0.0),
+            ],
+            EdgeDirection::CounterClockwise,
+        )
+        .expect("The polygon should be constructable");
+
+        let circle_5 = GreatCircle::new(SphericalPoint::new(1.0, 0.5), SphericalPoint::new(0.9, -0.15)).expect("The circle should be constructable");
+        let expected_i_1 = SphericalPoint::new(0.92165, 0.0);
+        let expected_i_2 = SphericalPoint::new(0.94532, 0.16371);
+        let expected_i_3 = SphericalPoint::new(0.97795, 0.37422);
+        let expected_i_4 = SphericalPoint::new(1.00878, 0.54583);
+        let intersections_2_5 = polygon_2
+            .great_circle_intersections(&circle_5)
+            .expect("It should be possible to determine if the circle intersects the polygon");
+        assert_eq!(intersections_2_5.len(), 4);
+        assert!(intersections_2_5.iter().any(|p| expected_i_1.approximately_equals(p, tolerance)));
+        assert!(intersections_2_5.iter().any(|p| expected_i_2.approximately_equals(p, tolerance)));
+        assert!(intersections_2_5.iter().any(|p| expected_i_3.approximately_equals(p, tolerance)));
+        assert!(intersections_2_5.iter().any(|p| expected_i_4.approximately_equals(p, tolerance)));
+
+        let circle_6 = GreatCircle::new(SphericalPoint::new(1.0, -0.5), SphericalPoint::new(0.9, -0.15)).expect("The circle should be constructable");
+        let expected_i_1 = SphericalPoint::new(0.69511, 0.58262);
+        let expected_i_2 = SphericalPoint::new(0.86191, 0.0);
+        let intersections_2_6 = polygon_2
+            .great_circle_intersections(&circle_6)
+            .expect("It should be possible to determine if the circle intersects the polygon");
+        assert_eq!(intersections_2_6.len(), 2);
+        dbg!(&intersections_2_6);
+        assert!(intersections_2_6.iter().any(|p| expected_i_1.approximately_equals(p, tolerance)));
+        assert!(intersections_2_6.iter().any(|p| expected_i_2.approximately_equals(p, tolerance)));
+
+        let circle_7 = GreatCircle::new(SphericalPoint::new(-0.1, -0.3), SphericalPoint::new(0.8, 0.7)).expect("The circle should be constructable");
+        let expected_i_1 = SphericalPoint::new(0.63939, 0.58435);
+        let expected_i_2 = SphericalPoint::new(0.13007, 0.0);
+        let intersections_2_7 = polygon_2
+            .great_circle_intersections(&circle_7)
+            .expect("It should be possible to determine if the circle intersects the polygon");
+        assert_eq!(intersections_2_7.len(), 2);
+        assert!(intersections_2_7.iter().any(|p| expected_i_1.approximately_equals(p, tolerance)));
+        assert!(intersections_2_7.iter().any(|p| expected_i_2.approximately_equals(p, tolerance)));
+
+        let circle_8 = GreatCircle::new(SphericalPoint::new(0.0, -0.5), SphericalPoint::new(0.9, -0.2)).expect("The circle should be constructable");
+        let intersections_2_8 = polygon_2
+            .great_circle_intersections(&circle_8)
+            .expect("It should be possible to determine if the circle intersects the polygon");
+        assert!(intersections_2_8.is_empty());
+
+        let circle_9 = GreatCircle::new(SphericalPoint::new(1.0, -0.5), SphericalPoint::new(0.90142, -0.15)).expect("The circle should be constructable");
+        let expected_i_1 = SphericalPoint::new(0.69950, 0.58243);
+        let expected_i_2 = SphericalPoint::new(0.80033, 0.25024);
+        let expected_i_3 = SphericalPoint::new(0.86387, 0.0);
+        let intersections_2_9 = polygon_2
+            .great_circle_intersections(&circle_9)
+            .expect("It should be possible to determine if the circle intersects the polygon");
+        assert_eq!(intersections_2_9.len(), 3);
+        assert!(intersections_2_9.iter().any(|p| expected_i_1.approximately_equals(p, tolerance)));
+        assert!(intersections_2_9.iter().any(|p| expected_i_2.approximately_equals(p, tolerance)));
+        assert!(intersections_2_9.iter().any(|p| expected_i_3.approximately_equals(p, tolerance)));
     }
 }

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -223,6 +223,33 @@ mod tests {
         assert!(!polygon_1
             .intersects_great_circle_arc(&arc_4)
             .expect("It should be possible to determine if the arc intersects the polygon"));
+
+        let polygon_2 = Polygon::new(
+            vec![
+                SphericalPoint::new(0.0, 0.0),
+                SphericalPoint::new(0.0, 0.5),
+                SphericalPoint::new(1.2, 0.5),
+                SphericalPoint::new(0.8, 0.25),
+                SphericalPoint::new(1.2, 0.0),
+            ],
+            EdgeDirection::CounterClockwise,
+        )
+        .expect("The polygon should be constructable");
+
+        let arc_5 = GreatCircleArc::new(SphericalPoint::new(1.0, 0.5), SphericalPoint::new(0.9, -0.15)).expect("The arc should be constructable");
+        assert!(polygon_2
+            .intersects_great_circle_arc(&arc_5)
+            .expect("It should be possible to determine if the arc intersects the polygon"));
+
+        let arc_6 = GreatCircleArc::new(SphericalPoint::new(1.0, -0.5), SphericalPoint::new(0.9, -0.15)).expect("The arc should be constructable");
+        assert!(!polygon_2
+            .intersects_great_circle_arc(&arc_6)
+            .expect("It should be possible to determine if the arc intersects the polygon"));
+
+        let arc_7 = GreatCircleArc::new(SphericalPoint::new(-0.1, -0.3), SphericalPoint::new(0.8, 0.7)).expect("The arc should be constructable");
+        assert!(polygon_2
+            .intersects_great_circle_arc(&arc_7)
+            .expect("It should be possible to determine if the arc intersects the polygon"));
     }
 
     #[test]
@@ -289,5 +316,22 @@ mod tests {
         assert!(intersections_2_5.iter().any(|p| expected_i_1.approximately_equals(p, tolerance)));
         assert!(intersections_2_5.iter().any(|p| expected_i_2.approximately_equals(p, tolerance)));
         assert!(intersections_2_5.iter().any(|p| expected_i_3.approximately_equals(p, tolerance)));
+
+        let arc_6 = GreatCircleArc::new(SphericalPoint::new(1.0, -0.5), SphericalPoint::new(0.9, -0.15)).expect("The arc should be constructable");
+        let intersections_2_6 = polygon_2
+            .great_circle_arc_intersections(&arc_6)
+            .expect("It should be possible to determine if the arc intersects the polygon");
+        assert!(intersections_2_6.is_empty());
+
+        let arc_7 = GreatCircleArc::new(SphericalPoint::new(-0.1, -0.3), SphericalPoint::new(0.8, 0.7)).expect("The arc should be constructable");
+        let intersections_2_7 = polygon_2
+            .great_circle_arc_intersections(&arc_7)
+            .expect("It should be possible to determine if the arc intersects the polygon");
+        dbg!(&intersections_2_7);
+        assert_eq!(intersections_2_7.len(), 2);
+        let expected_i_1 = SphericalPoint::new(0.13007, 0.0);
+        let expected_i_2 = SphericalPoint::new(0.63939, 0.58435);
+        assert!(intersections_2_7.iter().any(|p| expected_i_1.approximately_equals(p, tolerance)));
+        assert!(intersections_2_7.iter().any(|p| expected_i_2.approximately_equals(p, tolerance)));
     }
 }

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -174,7 +174,7 @@ impl Polygon {
     /// # Errors
     /// This function does not generate its own errors, but may propagate the following:
     ///  - If any of the edges fails to be constructed as a [GreatCircleArc], returns the corresponding error (see [GreatCircleArc::new]). This should however never happen, as that is checked when the polygon is constructed.
-    ///  - If an edge fails to be intersected with the circle, it returns the corresponding error (refer to [GreatCircle::intersect_great_circle_arc] for more details).
+    ///  - If an edge fails to be intersected with the circle, it returns the corresponding error (refer to [GreatCircleArc::intersect_great_circle] for more details).
     pub fn great_circle_intersections(&self, circle: &GreatCircle) -> Result<Vec<SphericalPoint>, SphericalError> {
         let mut intersections = Vec::new();
 
@@ -202,7 +202,7 @@ impl Polygon {
     /// # Errors
     /// This function does not generate its own errors, but may propagate the following:
     ///  - If any of the edges fails to be constructed as a [GreatCircleArc], returns the corresponding error (see [GreatCircleArc::new]). This should however never happen, as that is checked when the polygon is constructed.
-    ///  - If an edge fails to be intersected with the circle, it returns the corresponding error (refer to [GreatCircle::intersects_great_circle_arc] for more details). Handles parallel circles as infinite intersections (returns `Ok(true)`) though.
+    ///  - If an edge fails to be intersected with the circle, it returns the corresponding error (refer to [GreatCircleArc::intersects_great_circle] for more details). Handles parallel circles as infinite intersections (returns `Ok(true)`) though.
     pub fn intersects_great_circle(&self, circle: &GreatCircle) -> Result<bool, SphericalError> {
         for i in 0..self.vertices.len() - 1 {
             let edge = GreatCircleArc::new(self.vertices[i], self.vertices[i + 1])?;


### PR DESCRIPTION
This pull request adds functions to check if a polygon intersects a circle or an arc

It also adds functions to check for intersections without getting back the list of intersections, just a `true`/`false` answer

Closes #4