### PR TITLE
Use links in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### 🐛 Fixed
  - Fixed the example in README (GeCAA Theory task 7) (https://github.com/stellarguesser/spherical-geometry/pull/5)
 
+### 🔧 Improved
+- The documentation now uses links to mentioned structs or functions instead of code block references (https://github.com/stellarguesser/spherical-geometry/pull/9)
+
 ## 0.2.0 - 2024-10-07 - Polygons support
 This release focused on bringing in polygons support, but that required adding several other features :D
 

--- a/src/great_circle.rs
+++ b/src/great_circle.rs
@@ -13,7 +13,7 @@ impl GreatCircle {
     /// Creates a new great circle passing through the two points provided
     ///
     /// # Errors
-    /// If the points are essentially equal or essentially antipodal, returns `SphericalError::AntipodalOrTooClosePoints` as in the case of identical or antipodal points the great circle is not uniquely defined
+    /// If the points are essentially equal or essentially antipodal, returns [SphericalError::AntipodalOrTooClosePoints] as in the case of identical or antipodal points the great circle is not uniquely defined
     pub fn new(point1: SphericalPoint, point2: SphericalPoint) -> Result<Self, SphericalError> {
         if point1.cartesian().cross(&point2.cartesian()).magnitude_squared() < VEC_LEN_IS_ZERO.powi(2) {
             return Err(SphericalError::AntipodalOrTooClosePoints);
@@ -37,7 +37,7 @@ impl GreatCircle {
     /// Creates a new great circle passing through the provided point and perpendicular to the current circle
     ///
     /// # Errors
-    /// If the point and the pole of the current circle are essentially equal or essentially antipodal, returns `SphericalError::AntipodalOrTooClosePoints` as in the case of identical or antipodal points the great circle is not uniquely defined.
+    /// If the point and the pole of the current circle are essentially equal or essentially antipodal, returns [SphericalError::AntipodalOrTooClosePoints] as in the case of identical or antipodal points the great circle is not uniquely defined.
     pub fn perpendicular_through_point(&self, point: &SphericalPoint) -> Result<Self, SphericalError> {
         let point_1 = SphericalPoint::from_cartesian_vector3(self.normal());
         Self::new(point_1, *point)
@@ -61,7 +61,7 @@ impl GreatCircle {
     /// Returns the intersections of this great circle and another one
     ///
     /// # Errors
-    /// If the great circles are (essentially) parallel (equal to each other), returns `SphericalError::IdenticalGreatCircles` as then there is an infinite amount of intersections. You can handle this error as an equivalent of "all points on the circle are intersections".
+    /// If the great circles are (essentially) parallel (equal to each other), returns [SphericalError::IdenticalGreatCircles] as then there is an infinite amount of intersections. You can handle this error as an equivalent of "all points on the circle are intersections".
     pub fn intersect_great_circle(&self, other: &GreatCircle) -> Result<[SphericalPoint; 2], SphericalError> {
         let normal1 = self.normal();
         let normal2 = other.normal();

--- a/src/great_circle_arc.rs
+++ b/src/great_circle_arc.rs
@@ -13,7 +13,7 @@ impl GreatCircleArc {
     /// Creates a new great circle arc passing through the two points provided, taking the shorter of the two possible paths
     ///
     /// # Errors
-    /// If the points are essentially equal or essentially antipodal, returns `SphericalError::AntipodalOrTooClosePoints` as in the case of identical or antipodal points the great circle (and therefore also the arc) is not uniquely defined
+    /// If the points are essentially equal or essentially antipodal, returns [SphericalError::AntipodalOrTooClosePoints] as in the case of identical or antipodal points the great circle (and therefore also the arc) is not uniquely defined
     pub fn new(point1: SphericalPoint, point2: SphericalPoint) -> Result<Self, SphericalError> {
         if point1.cartesian().cross(&point2.cartesian()).magnitude_squared() < VEC_LEN_IS_ZERO.powi(2) {
             return Err(SphericalError::AntipodalOrTooClosePoints);
@@ -78,7 +78,7 @@ impl GreatCircleArc {
     /// Creates a new great circle passing through the provided point and perpendicular to the current circle arc
     ///
     /// # Errors
-    /// If the point and the pole of the current circle arc are essentially equal or essentially antipodal, returns `SphericalError::AntipodalOrTooClosePoints` as in the case of identical or antipodal points the great circle is not uniquely defined
+    /// If the point and the pole of the current circle arc are essentially equal or essentially antipodal, returns [SphericalError::AntipodalOrTooClosePoints] as in the case of identical or antipodal points the great circle is not uniquely defined
     pub fn perpendicular_circle_through_point(&self, point: &SphericalPoint) -> Result<GreatCircle, SphericalError> {
         let point_1 = SphericalPoint::from_cartesian_vector3(self.normal());
         GreatCircle::new(point_1, *point)
@@ -87,7 +87,7 @@ impl GreatCircleArc {
     /// Returns the intersections of this great circle arc with a great circle
     ///
     /// # Errors
-    /// If the great circle and the great circle containing the arc are (essentially) parallel (equal to each other), returns `SphericalError::IdenticalGreatCircles` as then there is an infinite amount of intersections. You can handle this error as an equivalent of "all points on the arc are intersections".
+    /// If the great circle and the great circle containing the arc are (essentially) parallel (equal to each other), returns [SphericalError::IdenticalGreatCircles] as then there is an infinite amount of intersections. You can handle this error as an equivalent of "all points on the arc are intersections".
     pub fn intersect_great_circle(&self, other: &GreatCircle) -> Result<Vec<SphericalPoint>, SphericalError> {
         let normal1 = self.normal();
         let normal2 = other.normal();
@@ -137,7 +137,7 @@ impl GreatCircleArc {
     /// Returns the intersections of this great circle arc with another one
     ///
     /// # Errors
-    /// If the great circles containing the arcs are (essentially) parallel (equal to each other) and overlapping, returns `SphericalError::IdenticalGreatCircles` as then there is an infinite amount of intersections.
+    /// If the great circles containing the arcs are (essentially) parallel (equal to each other) and overlapping, returns [SphericalError::IdenticalGreatCircles] as then there is an infinite amount of intersections.
     ///
     /// Propagates the rest of errors originating from [Self::intersect_great_circle]
     pub fn intersect_great_circle_arc(&self, other: &Self) -> Result<Vec<SphericalPoint>, SphericalError> {
@@ -191,7 +191,7 @@ impl GreatCircleArc {
     /// The provided circle is intended to be perpendicular to the arc as that is the only time this function will return meaningful results. It does not, however, rely on this being the case, so you can use it with any circle if you find it useful.
     ///
     /// # Errors
-    /// If the perpendicular great circle and the great circle containing the arc are (essentially) parallel (equal to each other), returns `SphericalError::IdenticalGreatCircles` as then there is an infinite amount of intersections. This should, however, never happen and would indicate a bug in the implementation.
+    /// If the perpendicular great circle and the great circle containing the arc are (essentially) parallel (equal to each other), returns [SphericalError::IdenticalGreatCircles] as then there is an infinite amount of intersections. This should, however, never happen and would indicate a bug in the implementation.
     pub fn closest_point_to_point_with_circle(&self, perpendicular_circle: &GreatCircle, point: &SphericalPoint) -> Result<SphericalPoint, SphericalError> {
         let normal1 = self.normal();
         let normal2 = perpendicular_circle.normal();
@@ -233,9 +233,9 @@ impl GreatCircleArc {
     /// Returns the closest point to the arc from a given point.
     ///
     /// # Errors
-    /// If the perpendicular great circle can not be constructed (usually because the given point is a pole of the circle containing the arc), returns `SphericalError::AntipodalOrTooClosePoints` as in the case of identical or antipodal points the great circle is not uniquely defined.
+    /// If the perpendicular great circle can not be constructed (usually because the given point is a pole of the circle containing the arc), returns [SphericalError::AntipodalOrTooClosePoints] as in the case of identical or antipodal points the great circle is not uniquely defined.
     ///
-    /// If the perpendicular great circle and the great circle containing the arc are (essentially) parallel (equal to each other), returns `SphericalError::IdenticalGreatCircles` as then there is an infinite amount of intersections. This should, however, never happen and would indicate a bug in the implementation.
+    /// If the perpendicular great circle and the great circle containing the arc are (essentially) parallel (equal to each other), returns [SphericalError::IdenticalGreatCircles] as then there is an infinite amount of intersections. This should, however, never happen and would indicate a bug in the implementation.
     pub fn closest_point_to_point(&self, point: &SphericalPoint) -> Result<SphericalPoint, SphericalError> {
         let perpendicular_circle = self.perpendicular_circle_through_point(point)?;
 
@@ -279,7 +279,7 @@ impl GreatCircleArc {
     /// Returns the intersections of the arc with the great circle, clamped to the arc. If there are no intersections, the endpoint closest to the potential intersections (of the great circle and the arc extended into a great circle) is returned.
     ///
     /// # Errors
-    /// If the great circle and the great circle containing the arc are (essentially) parallel (equal to each other), returns `SphericalError::IdenticalGreatCircles` as then there is an infinite amount of intersections. You can handle this error as an equivalent of "all points on the arc are intersections".
+    /// If the great circle and the great circle containing the arc are (essentially) parallel (equal to each other), returns [SphericalError::IdenticalGreatCircles] as then there is an infinite amount of intersections. You can handle this error as an equivalent of "all points on the arc are intersections".
     pub fn intersect_great_circle_clamped(&self, circle: &GreatCircle) -> Result<Vec<SphericalPoint>, SphericalError> {
         let normal1 = self.normal();
         let normal2 = circle.normal();
@@ -326,7 +326,7 @@ impl GreatCircleArc {
     /// Returns the intersections of the arc with the great circle, clamped to the arc. If there are no intersections, the endpoint closest to the point provided is returned.
     ///
     /// # Errors
-    /// If the great circle and the great circle containing the arc are (essentially) parallel (equal to each other), returns `SphericalError::IdenticalGreatCircles` as then there is an infinite amount of intersections. You can handle this error as an equivalent of "all points on the arc are intersections".
+    /// If the great circle and the great circle containing the arc are (essentially) parallel (equal to each other), returns [SphericalError::IdenticalGreatCircles] as then there is an infinite amount of intersections. You can handle this error as an equivalent of "all points on the arc are intersections".
     pub fn intersect_great_circle_clamped_closest_to_point(&self, circle: &GreatCircle, point: &SphericalPoint) -> Result<Vec<SphericalPoint>, SphericalError> {
         let normal1 = self.normal();
         let normal2 = circle.normal();

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,7 +1,7 @@
 use nalgebra::Vector3;
 use std::f32::consts::PI;
 
-/// A point on a unit sphere, given by its right ascension and declination
+/// A point on a unit sphere, determined by its right ascension and declination
 ///
 /// The right ascension is measured "from north to west" - the same way it goes if you look at the sky in the northern hemisphere. This means that at RA=0 you start at the x-axis and then with increasing RA you go towards negative values of y.
 #[derive(Clone, Copy, Debug)]
@@ -14,7 +14,7 @@ pub struct SphericalPoint {
 }
 
 impl SphericalPoint {
-    /// Constructs a new `SphericalPoint` given its right ascension (or azimuth or equivalent) and declination (or altitude or equivalent)
+    /// Constructs a new [Self] given its right ascension (or azimuth or equivalent) and declination (or altitude or equivalent)
     pub fn new(ra: f32, dec: f32) -> Self {
         let cartesian = Self::ra_dec_to_cartesian(ra, dec);
         Self {
@@ -26,7 +26,7 @@ impl SphericalPoint {
         }
     }
 
-    /// Constructs a new `SphericalPoint` given its cartesian coordinates as a `nalgebra` `Vector3<f32>`
+    /// Constructs a new [Self] given its cartesian coordinates as a [nalgebra::Vector3]
     pub fn from_cartesian_vector3(vector: Vector3<f32>) -> Self {
         let dec = PI / 2.0 - vector.normalize().z.acos();
         let mut ra = vector.y.atan2(vector.x);
@@ -36,7 +36,7 @@ impl SphericalPoint {
         Self::new(ra, dec)
     }
 
-    /// Constructs a new `SphericalPoint` given its cartesian coordinates
+    /// Constructs a new [Self] given its cartesian coordinates
     pub fn from_cartesian(x: f32, y: f32, z: f32) -> Self {
         Self::from_cartesian_vector3(Vector3::new(x, y, z))
     }
@@ -66,7 +66,7 @@ impl SphericalPoint {
         self.z
     }
 
-    /// Gets the cartesian coordinates of this point as a `nalgebra` `Vector3<f32>`
+    /// Gets the cartesian coordinates of this point as a [nalgebra::Vector3]
     pub fn cartesian(&self) -> Vector3<f32> {
         let x = self.dec.cos() * self.ra.cos();
         let y = self.dec.cos() * self.ra.sin();
@@ -74,7 +74,7 @@ impl SphericalPoint {
         Vector3::new(x, y, z)
     }
 
-    /// Constructs a new `nalgebra` `Vector3<f32>` given its right ascension (or azimuth or equivalent) and declination (or altitude or equivalent)
+    /// Constructs a new [nalgebra::Vector3] given its right ascension (or azimuth or equivalent) and declination (or altitude or equivalent)
     pub fn ra_dec_to_cartesian(ra: f32, dec: f32) -> Vector3<f32> {
         let x = dec.cos() * ra.cos();
         let y = -dec.cos() * ra.sin();
@@ -94,7 +94,7 @@ impl SphericalPoint {
 
     /// Calculates the angular distance between the points
     ///
-    /// If you need to sort points by distance, but do not need the actual angular values for each of them, consider using `SphericalPoint::minus_cotan_distance`
+    /// If you need to sort points by distance, but do not need the actual angular values for each of them, consider using [Self::minus_cotan_distance]
     pub fn distance(&self, other: &Self) -> f32 {
         let angle_sin = self.cartesian().cross(&other.cartesian()).magnitude();
         let angle_cos = self.cartesian().dot(&other.cartesian());

--- a/src/polygon.rs
+++ b/src/polygon.rs
@@ -11,7 +11,7 @@ use crate::{GreatCircle, GreatCircleArc, SphericalError, SphericalPoint, VEC_LEN
 ///
 /// ## More intuitive method
 /// Imagine you are standing on the **inside** surface of the sphere, your head pointing in the direction of the centre of the sphere.
-/// If you were to walk along the edge and the inside of the polygon was on your left choose `CounterClockwise`, else choose `Clockwise`.
+/// If you were to walk along the edge and the inside of the polygon was on your left choose [Self::CounterClockwise], else choose [Self::Clockwise].
 #[derive(Clone, Copy)]
 pub enum EdgeDirection {
     Clockwise,
@@ -33,10 +33,10 @@ impl Polygon {
     /// Flipping the direction of the edges will cause a polygon to be the complement of what you would expect to be your polygon (if you wanted to create a small triangle around the North Pole but flipped the edge orientation, you would define the polygon to be everywhere apart from the North Pole).
     ///
     /// # Panics
-    /// This function panics if no vertices were provided. That does not constitute a valid polygon and you should always provide at least two vertices.
+    /// This function panics if no vertices were provided. That does not constitute a valid polygon, and you should always provide at least two vertices.
     ///
     /// # Errors
-    /// If any edge is defined by essentially equal or antipodal points, returns `SphericalError::AntipodalOrTooClosePoints` as in the case of identical or antipodal points the great circle (and therefore also the edge) is not uniquely defined.
+    /// If any edge is defined by essentially equal or antipodal points, returns [SphericalError::AntipodalOrTooClosePoints] as in the case of identical or antipodal points the great circle (and therefore also the edge) is not uniquely defined.
     pub fn new(vertices_in: Vec<SphericalPoint>, edges_direction: EdgeDirection) -> Result<Self, SphericalError> {
         let mut vertices = vertices_in;
         if !vertices[0].approximately_equals(&vertices[vertices.len() - 1], VEC_LEN_IS_ZERO) {
@@ -66,7 +66,7 @@ impl Polygon {
     /// # Errors
     /// This function does not produce its own errors, but it will propagate inner errors out, see below. That should however never happen - if it does, it is a bug in an implementation in the library, so please report it should you encounter it.
     ///
-    /// If any of the edges fails to be constructed as a `GreatCircleArc`, returns the corresponding error. This should however never happen, as that is checked when the polygon is constructed.
+    /// If any of the edges fails to be constructed as a [GreatCircleArc], returns the corresponding error. This should however never happen, as that is checked when the polygon is constructed.
     ///
     /// Also, if any intersections fail the corresponding error will be returned. This should however also never happen.
     pub fn contains_point(&self, point: &SphericalPoint) -> Result<bool, SphericalError> {


### PR DESCRIPTION
This pull request replaces code block references (`GreatCircle`) with links in the documentation comments. This makes it easier for the users (they can click the link to go to the mentioned struct, function, ...) and also for maintenance - if the struct name changes, `cargo doc` will display warnings, making it easy to fix the documentation.

Closes #7 